### PR TITLE
AutoResponses — Rate limit, remove command, list command

### DIFF
--- a/ClearChat.Core/Domain/AutoResponseTemplate.cs
+++ b/ClearChat.Core/Domain/AutoResponseTemplate.cs
@@ -1,0 +1,16 @@
+﻿namespace ClearChat.Core.Domain
+{
+    public class AutoResponseTemplate
+    {
+        public byte[] CreatorIdHash { get; }
+        public string SubstringTrigger { get; }
+        public string Response { get; }
+
+        public AutoResponseTemplate(byte[] creatorIdHash, string substringTrigger, string response)
+        {
+            CreatorIdHash = creatorIdHash;
+            SubstringTrigger = substringTrigger;
+            Response = response;
+        }
+    }
+}

--- a/ClearChat.Core/Repositories/IAutoResponseRepository.cs
+++ b/ClearChat.Core/Repositories/IAutoResponseRepository.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using ClearChat.Core.Domain;
+using ClearChat.Core.Exceptions;
+
+namespace ClearChat.Core.Repositories
+{
+    public interface IAutoResponseRepository
+    {
+        /// <summary>
+        /// Gets auto response for given message
+        /// </summary>
+        /// <remarks>Can return null</remarks>
+        string GetResponse(string message);
+
+        /// <summary>
+        /// Registers an auto response with the server
+        /// </summary>
+        /// <exception cref="DuplicateAutoResponseException">
+        /// Auto response for given phrase already exists
+        /// </exception>
+        void AddResponse(string creatorId, string substring, string response);
+
+        void RemoveResponse(string substring);
+
+        IReadOnlyCollection<AutoResponseTemplate> GetAll();
+    }
+}

--- a/ClearChat.Core/Repositories/RateLimitingAutoResponseRepository.cs
+++ b/ClearChat.Core/Repositories/RateLimitingAutoResponseRepository.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+using ClearChat.Core.Domain;
+
+namespace ClearChat.Core.Repositories
+{
+    public class RateLimitingAutoResponseRepository : IAutoResponseRepository
+    {
+        private readonly ConcurrentDictionary<string, DateTime> m_LastHits 
+            = new ConcurrentDictionary<string, DateTime>();
+
+        private readonly IAutoResponseRepository m_InnerRepository;
+        private readonly TimeSpan m_MinimumResponseInterval;
+
+        public RateLimitingAutoResponseRepository(IAutoResponseRepository innerRepository, 
+                                                  TimeSpan minimumResponseInterval)
+        {
+            m_InnerRepository = innerRepository;
+            m_MinimumResponseInterval = minimumResponseInterval;
+            foreach (var autoResponse in innerRepository.GetAll())
+            {
+                m_LastHits.TryAdd(autoResponse.SubstringTrigger,
+                    DateTime.MinValue.ToUniversalTime());
+            }
+        }
+
+        public string GetResponse(string message)
+        {
+            var response = m_LastHits.Keys.FirstOrDefault(k => message.Contains(k));
+            if (response != null)
+            {
+                var now = DateTime.UtcNow;
+                if (now - m_LastHits[response] < m_MinimumResponseInterval) return null;
+                m_LastHits[response] = now;
+            }
+
+            return m_InnerRepository.GetResponse(message);
+        }
+
+        public void AddResponse(string creatorId, string substring, string response)
+        {
+            m_InnerRepository.AddResponse(creatorId, substring, response);
+            m_LastHits.TryAdd(substring, DateTime.MinValue.ToUniversalTime());
+        }
+
+        public void RemoveResponse(string substring)
+        {
+            m_InnerRepository.RemoveResponse(substring);
+            m_LastHits.TryRemove(substring, out DateTime _);
+        }
+
+        public IReadOnlyCollection<AutoResponseTemplate> GetAll()
+        {
+            return m_InnerRepository.GetAll();
+        }
+    }
+}

--- a/ClearChat.Web/MessageHandling/SlashCommands/AutoResponseCommand.cs
+++ b/ClearChat.Web/MessageHandling/SlashCommands/AutoResponseCommand.cs
@@ -39,12 +39,6 @@ namespace ClearChat.Web.MessageHandling.SlashCommands
                 return;
             }
 
-            if (response.Contains(substringTrigger))
-            {
-                context.MessageHub.PublishSystemMessage(context.ConnectionId, "Error: that is silly. Think about it.");
-                return;
-            }
-
             try
             {
                 m_AutoResponseRepository.AddResponse(context.UserId, substringTrigger, response);

--- a/ClearChat.Web/MessageHandling/SlashCommands/ListAutoResponseCommand.cs
+++ b/ClearChat.Web/MessageHandling/SlashCommands/ListAutoResponseCommand.cs
@@ -1,0 +1,37 @@
+﻿
+using System;
+
+using ClearChat.Core.Domain;
+using ClearChat.Core.Repositories;
+
+namespace ClearChat.Web.MessageHandling.SlashCommands
+{
+    public class ListAutoResponseCommand : ISlashCommand
+    {
+        private readonly IAutoResponseRepository m_AutoResponseRepository;
+
+        public ListAutoResponseCommand(IAutoResponseRepository autoResponseRepository)
+        {
+            m_AutoResponseRepository = autoResponseRepository
+                                       ?? throw new ArgumentNullException(nameof(autoResponseRepository));
+        }
+
+        public string CommandText => "listautoresponse";
+
+        public void Handle(MessageContext context, string arguments)
+        {
+            var autoResponses = m_AutoResponseRepository.GetAll();
+            foreach (var response in autoResponses)
+            {
+                context.MessageHub.PublishSystemMessage(context.ConnectionId, $"\"{response.SubstringTrigger}\" => \"{response.Response}\"");
+            }
+
+            if (autoResponses.Count == 0)
+            {
+                context.MessageHub.PublishSystemMessage(context.ConnectionId, "There are none.");
+            }
+        }
+
+        public string HelpText => "List all automatic responses.";
+    }
+}

--- a/ClearChat.Web/MessageHandling/SlashCommands/RemoveAutoResponseCommand.cs
+++ b/ClearChat.Web/MessageHandling/SlashCommands/RemoveAutoResponseCommand.cs
@@ -35,7 +35,7 @@ namespace ClearChat.Web.MessageHandling.SlashCommands
             context.MessageHub.PublishSystemMessage(context.ConnectionId, $"Successfully removed auto response for '{parameterArray[0]}'.");
         }
 
-        public string HelpText => "Adds an automatic response, usage /autoresponse \"ping\" \"pong\"";
+        public string HelpText => "Removes an automatic response, usage /removeautoresponse \"ping\"";
 
         private static string[] SplitParameters(string input)
         {

--- a/ClearChat.Web/MessageHandling/SlashCommands/RemoveAutoResponseCommand.cs
+++ b/ClearChat.Web/MessageHandling/SlashCommands/RemoveAutoResponseCommand.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using ClearChat.Core.Domain;
+using ClearChat.Core.Repositories;
+
+namespace ClearChat.Web.MessageHandling.SlashCommands
+{
+    public class RemoveAutoResponseCommand : ISlashCommand
+    {
+        private readonly IAutoResponseRepository m_AutoResponseRepository;
+
+        public RemoveAutoResponseCommand(IAutoResponseRepository autoResponseRepository)
+        {
+            m_AutoResponseRepository = autoResponseRepository
+                                       ?? throw new ArgumentNullException(nameof(autoResponseRepository));
+        }
+
+        public string CommandText => "removeautoresponse";
+
+        public void Handle(MessageContext context, string arguments)
+        {
+            var parameters = SplitParameters(arguments);
+
+            if (parameters.Length != 1)
+            {
+                context.MessageHub.PublishSystemMessage(context.ConnectionId, "Error: correct usage is /removeautoresponse \"ping\"");
+                return;
+            }
+
+            var parameterArray = parameters.ToArray();
+
+            m_AutoResponseRepository.RemoveResponse(parameterArray[0]);
+
+            context.MessageHub.PublishSystemMessage(context.ConnectionId, $"Successfully removed auto response for '{parameterArray[0]}'.");
+        }
+
+        public string HelpText => "Adds an automatic response, usage /autoresponse \"ping\" \"pong\"";
+
+        private static string[] SplitParameters(string input)
+        {
+            return Regex.Matches(input, @"[\""].+?[\""]|[^ ]+")
+                .Select(m => m.Value.Trim('\"'))
+                .ToArray();
+        }
+    }
+}


### PR DESCRIPTION
- Took Regex from S.O. which parses with or without quotes
- ClearBot won't reply with the same thing within 20 minutes. Slightly more human than real SlackBot.
- Added some validation so you can't make really annoying ones which trigger on fewer than 4 characters. So no 'the' or 'and' or whatever.
- Ability to remove responses.
- Ability to list existing ones. Might be more fun if you can only list your own, not sure.